### PR TITLE
fix: add execution permission for entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ ENV MINIO_API_VERSION="S3v4"
 ENV DATE_FORMAT="+%Y-%m-%d"
 
 ADD entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]


### PR DESCRIPTION
Had issue with Kubernetes not being able to start docker pod due to permission error to execute entrypoint. This fixes that issue